### PR TITLE
add '--syncdeps', remove pkg cache, squash docker layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,27 @@
-FROM archlinux:base-devel
+FROM archlinux:base-devel as base
 
-MAINTAINER Spencer Rinehart <anubis@overthemonkey.com>
-
-RUN pacman --sync --refresh --sysupgrade --noconfirm --noprogressbar --quiet && \
-  pacman --sync --noconfirm --noprogressbar --quiet git namcap
+RUN pacman --sync --refresh --sysupgrade --noconfirm --noprogressbar --quiet
+RUN pacman --sync --noconfirm --noprogressbar --quiet git namcap
+RUN yes | pacman --sync -cc
 
 RUN useradd --create-home --comment "Arch Build User" build
-ENV HOME /home/build
+RUN usermod -aG wheel build
+RUN echo '%wheel     ALL=(ALL) NOPASSWD:ALL' >>  /etc/sudoers
 
 RUN mkdir /package
 RUN chown build /package
+
+FROM scratch
+
+MAINTAINER Spencer Rinehart <anubis@overthemonkey.com>
+
+ENV LANG=en_US.UTF-8
+ENV HOME /home/build
+
 WORKDIR /package
 
 USER build
 
-CMD ["makepkg", "--force"]
+COPY --from=base / /
+
+CMD ["makepkg", "--force", "--syncdeps"]


### PR DESCRIPTION
- '--syncdeps' param added, so pacman will install missing dependencies
- pacman cache has been cleaned
- docker layers has been stripped

new uncompressed image size 796MB vs 872MB 